### PR TITLE
Log processor

### DIFF
--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -31,7 +31,7 @@ class LogProcessor(object):
         self.context = context
         self.readers = {}
 
-    def process_logs(self, logs, ref_type='folder'):
+    def process_logs(self, logs, ref_type='folder', **kwargs):
         """
         Process the specified logs
 
@@ -45,6 +45,12 @@ class LogProcessor(object):
                     * "folder" : specifying a directory or nested directory of
                         JSON logs
                 Defaults to "folder"
+            **kwargs :
+                Additional keyword arguments specific to the ref_type.
+                    * "file" and "files" require:
+                        * date (:obj:`datetime.datetime`) :
+                            the date on which the battle took place
+                        * format (:obj:`str`) : sanitized name of the metagame
 
         Returns:
             int :

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -1,0 +1,52 @@
+"""Functionality for processing of logs and routing parsed data to sinks"""
+import glob
+
+from onix import contexts
+from onix.collection import log_reader
+from onix.collection import sinks
+
+
+class LogProcessor(object):
+    """
+    Executor in charge of processing battle logs and routing the parsed data to
+    the appropriate sinks
+
+    Args:
+        moveset_sink (sinks.MovesetSink) : The sink to route movesets data
+        battle_info_sink (sinks.BattleInfoSink) :
+            The sink to route battle metadata
+        battle_sink (sinks.BattleSink) :
+            The sink to route the actual turn-by-turn battle representations
+        context (onix.contexts.Context) :
+            The resources needed by the log reader. Must have: pokedex, items,
+            formats, sanitizer, accessible_formes and natures
+    """
+
+    def __init__(self, moveset_sink, battle_info_sink, battle_sink, context):
+        contexts.require(context, 'sanitizer', 'pokedex', 'items', 'formats',
+                         'natures', 'accessible_formes')
+        self.moveset_sink = moveset_sink
+        self.battle_info_sink = battle_info_sink
+        self.battle_sink = battle_sink
+        self.context = context
+        self.readers = {}
+
+    def process_logs(self, logs, ref_type='folder'):
+        """
+        Process the specified logs
+
+        Args:
+            logs : Reference to the logs to process
+            ref_type (:obj:`str`, optional) :
+                Description of the `logs` parameter specifying how to handle it.
+                Options are:
+                    * "file" : specifying a single JSON log
+                    * "files" : specifying an iterable of JSON logs
+                    * "folder" : specifying a directory or nested directory of
+                        JSON logs
+                Defaults to "folder"
+
+        Returns:
+            int :
+                the number of logs processed successfully
+        """

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -97,6 +97,7 @@ class LogProcessor(object):
                 log-parsing errors. Options are:
                     * "raise" : raise an exception if an error is encountered.
                     * "skip" : silently skip problematic logs
+                Defaults to "raise"
 
         Returns:
             int :
@@ -136,6 +137,9 @@ class LogProcessor(object):
                     all_movesets.update(movesets)
                     battles.append(battle)
                     succesful_count += 1
+            else:
+                raise ValueError('Unrecognized ref_type: '
+                                 '{0}'.format(ref_type))
 
         except log_reader.ParsingError:
             if error_handling == 'raise':
@@ -143,7 +147,7 @@ class LogProcessor(object):
             elif error_handling == 'skip':
                 pass
             else:
-                raise ValueError('Unrecognized error-handling strategy:'
+                raise ValueError('Unrecognized error-handling strategy: '
                                  '{0}'.format(error_handling))
 
         if self.battle_info_sink:
@@ -153,7 +157,7 @@ class LogProcessor(object):
         if self.moveset_sink:
             self.moveset_sink.store_movesets(all_movesets)
 
-        if self.battle_sink:
+        if self.battle_sink:  # pragma: no cover TODO: remove when battles
             for battle in battles:
                 self.battle_sink.store_battle(battle)
 
@@ -176,8 +180,8 @@ class LogProcessor(object):
         """
         reader = self._get_log_reader(log_ref)
         if reader is None:
-            raise log_reader.ParsingError(log_ref, "Could not identify a"
-                                                   "suitable log reader for the"
+            raise log_reader.ParsingError(log_ref, "Could not identify a "
+                                                   "suitable reader for the "
                                                    "log")
         return reader.parse_log(log_ref)
 

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -108,18 +108,28 @@ class LogProcessor(object):
         battles = []
         count = 0
         if ref_type == 'file':
-            battle_info, movesets, battle = self._process_single_log(logs)
-            battle_infos.append(battle_info)
-            all_movesets.update(movesets)
-            battles.append(battle)
-            count += 1
+            try:
+                battle_info, movesets, battle = self._process_single_log(logs)
+                battle_infos.append(battle_info)
+                all_movesets.update(movesets)
+                battles.append(battle)
+                count += 1
+
+            except log_reader.ParsingError:
+                if error_handling == 'raise':
+                    raise
+                elif error_handling == 'skip':
+                    pass
+                else:
+                    raise ValueError('Unrecognized error-handling strategy:'
+                                     '{0}'.format(error_handling))
 
         if self.battle_info_sink:
             for battle_info in battle_infos:
                 self.battle_info_sink.store_battle_info(battle_info)
 
         if self.moveset_sink:
-            self.moveset_sink.store_movesets(movesets)
+            self.moveset_sink.store_movesets(all_movesets)
 
         if self.battle_sink:
             for battle in battles:

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -9,7 +9,9 @@ from onix.collection import sinks
 class LogProcessor(object):
     """
     Executor in charge of processing battle logs and routing the parsed data to
-    the appropriate sinks
+    the appropriate sinks. The LogProcessor is in charge of instantiating
+    ``LogReader``s to process the logs that come in based on the format of the
+    log (_e.g._ JSON file) and the metagame of the battle.
 
     Args:
         moveset_sink (sinks.MovesetSink) : The sink to route movesets data
@@ -17,18 +19,18 @@ class LogProcessor(object):
             The sink to route battle metadata
         battle_sink (sinks.BattleSink) :
             The sink to route the actual turn-by-turn battle representations
-        context (onix.contexts.Context) :
-            The resources needed by the log reader. Must have: pokedex, items,
-            formats, sanitizer, accessible_formes and natures
+        force_context_refresh (:obj:`bool`, optional) : Defaults to False. If
+            True, any contexts that get loaded will be pull fresh data from
+            Pokemon Showdown rather than rely on the local cache.
     """
 
-    def __init__(self, moveset_sink, battle_info_sink, battle_sink, context):
+    def __init__(self, moveset_sink, battle_info_sink, battle_sink,
+                 force_context_refresh=False):
         contexts.require(context, 'sanitizer', 'pokedex', 'items', 'formats',
                          'natures', 'accessible_formes')
         self.moveset_sink = moveset_sink
         self.battle_info_sink = battle_info_sink
         self.battle_sink = battle_sink
-        self.context = context
         self.readers = {}
 
     def process_logs(self, logs, ref_type='folder', **kwargs):

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -106,14 +106,14 @@ class LogProcessor(object):
         battle_infos = []
         all_movesets = dict()
         battles = []
-        count = 0
+        succesful_count = 0
         if ref_type == 'file':
             try:
                 battle_info, movesets, battle = self._process_single_log(logs)
                 battle_infos.append(battle_info)
                 all_movesets.update(movesets)
                 battles.append(battle)
-                count += 1
+                succesful_count += 1
 
             except log_reader.ParsingError:
                 if error_handling == 'raise':
@@ -134,6 +134,8 @@ class LogProcessor(object):
         if self.battle_sink:
             for battle in battles:
                 self.battle_sink.store_battle(battle)
+
+        return succesful_count
 
     def _process_single_log(self, log_ref):
         """

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -1,5 +1,4 @@
 """Functionality for processing of logs and routing parsed data to sinks"""
-import glob
 import os
 
 from onix import contexts
@@ -107,22 +106,35 @@ class LogProcessor(object):
         all_movesets = dict()
         battles = []
         succesful_count = 0
-        if ref_type == 'file':
-            try:
+
+        try:
+            if ref_type == 'file':
                 battle_info, movesets, battle = self._process_single_log(logs)
                 battle_infos.append(battle_info)
                 all_movesets.update(movesets)
                 battles.append(battle)
                 succesful_count += 1
 
-            except log_reader.ParsingError:
-                if error_handling == 'raise':
-                    raise
-                elif error_handling == 'skip':
-                    pass
-                else:
-                    raise ValueError('Unrecognized error-handling strategy:'
-                                     '{0}'.format(error_handling))
+            elif ref_type == 'files':
+                for log_ref in logs:
+                    battle_info, movesets, battle = self._process_single_log(
+                        log_ref)
+                    battle_infos.append(battle_info)
+                    all_movesets.update(movesets)
+                    battles.append(battle)
+                    succesful_count += 1
+
+            elif ref_type == 'folder':
+                pass
+
+        except log_reader.ParsingError:
+            if error_handling == 'raise':
+                raise
+            elif error_handling == 'skip':
+                pass
+            else:
+                raise ValueError('Unrecognized error-handling strategy:'
+                                 '{0}'.format(error_handling))
 
         if self.battle_info_sink:
             for battle_info in battle_infos:

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -26,8 +26,7 @@ class LogProcessor(object):
 
     def __init__(self, moveset_sink, battle_info_sink, battle_sink,
                  force_context_refresh=False):
-        contexts.require(context, 'sanitizer', 'pokedex', 'items', 'formats',
-                         'natures', 'accessible_formes')
+
         self.moveset_sink = moveset_sink
         self.battle_info_sink = battle_info_sink
         self.battle_sink = battle_sink

--- a/onix/collection/log_processor.py
+++ b/onix/collection/log_processor.py
@@ -125,7 +125,17 @@ class LogProcessor(object):
                     succesful_count += 1
 
             elif ref_type == 'folder':
-                pass
+                # if I only had to support python 3.5+, I could use glob.glob...
+                for log_ref in [os.path.join(dirpath, filename)
+                                for dirpath, _, filenames in os.walk(logs)
+                                for filename in filenames
+                                if filename.endswith('.log.json')]:
+                    battle_info, movesets, battle = self._process_single_log(
+                        log_ref)
+                    battle_infos.append(battle_info)
+                    all_movesets.update(movesets)
+                    battles.append(battle)
+                    succesful_count += 1
 
         except log_reader.ParsingError:
             if error_handling == 'raise':

--- a/onix/collection/log_reader.py
+++ b/onix/collection/log_reader.py
@@ -266,7 +266,6 @@ class LogReader(with_metaclass(abc.ABCMeta, object)):
              mega_rayquaza_allowed) = utilities.parse_ruleset(
                 self.context.formats[log['format']])
 
-
             movesets = {}
             players = []
             teams = []

--- a/onix/collection/log_reader.py
+++ b/onix/collection/log_reader.py
@@ -254,7 +254,7 @@ class LogReader(with_metaclass(abc.ABCMeta, object)):
                 * Battle : a structured turn-by-turn recounting of the battle
 
         Raises:
-            ParsingError: if there's a problem parsing the log
+            ParsingError : if there's a problem parsing the log
         """
 
         try:

--- a/onix/collection/log_reader.py
+++ b/onix/collection/log_reader.py
@@ -290,7 +290,7 @@ class LogReader(with_metaclass(abc.ABCMeta, object)):
         except ParsingError:
             raise
         except Exception as err:
-            raise ParsingError(log_ref, 'Log could not be parsed because of'
+            raise ParsingError(log_ref, 'Log could not be parsed because of '
                                         '{0}'.format(repr(err)))
 
         return battle_info, movesets, None
@@ -319,13 +319,14 @@ class LogReader(with_metaclass(abc.ABCMeta, object)):
         ivs = utilities.stats_dict_to_dto(moveset_dict['ivs'])
         evs = utilities.stats_dict_to_dto(moveset_dict['evs'])
         nature = self.context.natures[
-            self.context.sanitizer.sanitize(moveset_dict['nature'])]
+            self.context.sanitizer.sanitize(moveset_dict['nature'] or 'hardy')]
         level = moveset_dict.get('level', 100)
         happiness = moveset_dict.get('happiness', 255)
 
         if item == '':
             item = None
-            moves = normalize_hidden_power(moves, ivs)
+
+        moves = normalize_hidden_power(moves, ivs)
 
         formes = get_all_formes(species, ability, item, moves,
                                 self.context, hackmons,

--- a/onix/collection/log_reader.py
+++ b/onix/collection/log_reader.py
@@ -198,7 +198,7 @@ class LogReader(six.with_metaclass(abc.ABCMeta, object)):
 
     def __init__(self, metagame, context):
         contexts.require(context, 'sanitizer', 'pokedex', 'items', 'formats',
-                          'natures', 'accessible_formes')
+                         'natures', 'accessible_formes')
 
         self.metagame = metagame
         self.context = context

--- a/onix/resources/natures.json
+++ b/onix/resources/natures.json
@@ -113,7 +113,5 @@
     "name": "Timid",
     "plus": "spe",
     "minus": "atk"
-  },
-  "": {
   }
 }

--- a/onix/scripts/log_generator.py
+++ b/onix/scripts/log_generator.py
@@ -96,7 +96,7 @@ def generate_pokemon(species, context,
         'ability': ability,
         'nature': context.natures[nature]['name'],
         'item': item,
-        'moves': _normalize_hidden_power(moves, ivs),
+        'moves': normalize_hidden_power(moves, ivs),
         'ivs': iv_dict,
         'evs': ev_dict,
         'level': level,
@@ -117,16 +117,15 @@ def generate_pokemon(species, context,
     return pokemon_dict, moveset
 
 
-def generate_player(name, ratings=None):
+def generate_player(name, **ratings):
     """
     Generate a Showdown-style player's rating dict and the corresponding
     `Player` DTO for the given species
 
     Args:
         name (str) : the player's name
-        ratings (:obj:`dict`, optional) : the rating values for the player.
-            Missing values will be randomly generated. Defaults to having all
-            values randomly generated
+        **ratings : values to put in the player's rating dict. Unset values
+            will be randomly generated.
 
     Returns:
         (tuple) :

--- a/onix/scripts/log_generator.py
+++ b/onix/scripts/log_generator.py
@@ -148,7 +148,7 @@ def generate_player(name, **ratings):
     rprd = ratings.get('rprd', rd - random.uniform(0, 25))
 
     rating_dict = dict(elo=elo,
-                       formatid=ratings.get('format', 'randombattle'),
+                       formatid=ratings.get('formatid', 'randombattle'),
                        l=l, r=r, rd=rd,  rpr=rpr, rprd=rprd,
                        rpsigma=ratings.get('rpsigma', 0),
                        rptime=ratings.get('rptime',

--- a/onix/tests/collection/test_log_processor.py
+++ b/onix/tests/collection/test_log_processor.py
@@ -1,7 +1,19 @@
 """Tests for the log_processor module"""
+import datetime
+import json
+import shutil
+import os
 
+import pytest
+
+from collections import defaultdict
+
+from onix import contexts
 from onix import utilities
+from onix.collection import log_reader as lr
+from onix.collection import log_processor as lp
 from onix.collection import sinks
+from onix.scripts import log_generator as lg
 
 
 class StumpMovesetSink(sinks.MovesetSink):
@@ -24,7 +36,7 @@ class StumpBattleInfoSink(sinks.BattleInfoSink):
     def __init__(self):
         self.pids = set()
         self.tids = set()
-        self.battles = set()
+        self.battles = defaultdict(set)
 
     def store_battle_info(self, battle_info):
         start_sizes = {'players': len(self.pids),
@@ -34,9 +46,91 @@ class StumpBattleInfoSink(sinks.BattleInfoSink):
         self.pids.update([player.id for player in battle_info.players])
         self.tids.update([utilities.compute_tid(team)
                           for team in battle_info.slots])
-        self.battles.add(battle_info.id)
+        self.battles[battle_info.format].add(battle_info.id)
 
         return {'players': len(self.pids) - start_sizes['players'],
                 'teams': len(self.tids) - start_sizes['teams'],
                 'battles': len(self.battles) - start_sizes['battles']}
+
+
+def test_processor_without_sinks():
+    """Should still work, should still parse the logs, even though nothing
+    actually gets persisted"""
+    context = contexts.get_standard_context()
+
+    players = [lg.generate_player(username)[0]
+               for username in ['Alice', 'Bob']]
+
+    moveset, _ = lg.generate_pokemon('articuno', context)
+
+    log = lg.generate_log(players, [[moveset, moveset]])
+
+    try:
+        json.dump(log, open('battle-randombattle-134341313.log.json', 'w+'))
+        p = lp.LogProcessor(None, None, None)
+        result = p.process_logs('battle-randombattle-134341313.log.json',
+                                ref_type='file',
+                                format='randombattle',
+                                date=datetime.datetime(2016, 8, 31))
+        assert 1 == result
+
+        assert 1 == len(p.readers)
+        reader = list(p.readers.values())[0]
+        assert isinstance(reader, lr.JsonFileLogReader)
+        assert 'randombattle' == reader.metagame
+
+    finally:
+        os.remove('egagadga.log.json')
+
+
+def test_process_single_log():
+    context = contexts.get_standard_context()
+
+    players = [lg.generate_player(username, formatid='ou')[0]
+               for username in ['Alice', 'Bob']]
+
+    movesets = [lg.generate_pokemon(species, context)[0]
+                for species in ['alakazammega',
+                                'bisharp',
+                                'cacturne',
+                                'delphox',
+                                'electabuzz',
+                                'flygon',
+                                'gogoat',
+                                'hariyama',
+                                'infernape',
+                                'jumpluff',
+                                'bisharp']]
+
+    teams = [movesets[:6], movesets[5:]]
+
+    log = lg.generate_log(players, teams)
+
+    try:
+        json.dump(log, open('wtafda.log.json', 'w+'))
+        p = lp.LogProcessor(StumpMovesetSink(), StumpBattleInfoSink(), None)
+        p.process_logs('wtafda.log.json', ref_type='file',
+                       format='ou', date=datetime.datetime(2016, 8, 31))
+
+        result = p.process_logs('egagadga.log.json', ref_type='file',
+                                format='ou',
+                                date=datetime.datetime(2016, 8, 31))
+        assert 1 == result
+
+        assert 1 == len(p.readers)
+        reader = list(p.readers.values())[0]
+        assert isinstance(reader, lr.JsonFileLogReader)
+        assert 'ou' == reader.metagame
+
+        assert 11 == len(p.moveset_sink.sids)
+        assert 2 == len(p.battle_info_sink.pids)
+        assert 2 == len(p.battle_info_sink.tids)
+        assert 1 == len(p.battle_info_sink.battles)
+
+    finally:
+        os.remove('wtafda.log.json')
+
+
+
+
 

--- a/onix/tests/collection/test_log_processor.py
+++ b/onix/tests/collection/test_log_processor.py
@@ -1,5 +1,6 @@
 """Tests for the log_processor module"""
 import datetime
+import glob
 import json
 import shutil
 import os
@@ -10,7 +11,6 @@ from collections import defaultdict
 
 from onix import contexts
 from onix import utilities
-from onix.collection import log_reader as lr
 from onix.collection import log_processor as lp
 from onix.collection import sinks
 from onix.scripts import log_generator as lg
@@ -63,7 +63,7 @@ def test_processor_without_sinks():
 
     moveset, _ = lg.generate_pokemon('articuno', context)
 
-    log = lg.generate_log(players, [[moveset, moveset]])
+    log = lg.generate_log(players, [[moveset], [moveset]])
 
     try:
         json.dump(log, open('battle-randombattle-134341313.log.json', 'w+'))
@@ -75,7 +75,7 @@ def test_processor_without_sinks():
         assert 1 == result
 
     finally:
-        os.remove('egagadga.log.json')
+        os.remove('battle-randombattle-134341313.log.json')
 
 
 def test_process_single_log():
@@ -102,14 +102,11 @@ def test_process_single_log():
     log = lg.generate_log(players, teams)
 
     try:
-        json.dump(log, open('wtafda.log.json', 'w+'))
+        json.dump(log, open('battle-ou-195629539.log.json', 'w+'))
         p = lp.LogProcessor(StumpMovesetSink(), StumpBattleInfoSink(), None)
-        p.process_logs('wtafda.log.json', ref_type='file',
-                       format='ou', date=datetime.datetime(2016, 8, 31))
 
-        result = p.process_logs('egagadga.log.json', ref_type='file',
-                                format='ou',
-                                date=datetime.datetime(2016, 8, 31))
+        result = p.process_logs('battle-ou-195629539.log.json', ref_type='file')
+
         assert 1 == result
 
         assert 11 == len(p.moveset_sink.sids)
@@ -119,7 +116,101 @@ def test_process_single_log():
         assert 1 == len(p.battle_info_sink.battles['ou'])
 
     finally:
-        os.remove('wtafda.log.json')
+        os.remove('battle-ou-195629539.log.json')
+
+
+class TestProcessMultipleLogs(object):
+
+    def setup_method(self, method):
+        self.context = contexts.get_standard_context()
+
+        players = [lg.generate_player(username, formatid='uu')[0]
+                   for username in ('Alice', 'Bob')]
+        players += [lg.generate_player(username, formatid='ou')[0]
+                    for username in ('Charley', 'Delia')]
+        players.append(lg.generate_player('Eve', formatid='uu')[0])
+
+        movesets = [lg.generate_pokemon(species, self.context)[0]
+                    for species in ('alakazammega',
+                                    'bisharp',
+                                    'cacturne',
+                                    'delphox',
+                                    'electabuzz',
+                                    'flygon',
+                                    'gogoat',
+                                    'hariyama',
+                                    'infernape',
+                                    'jumpluff',
+                                    'kangaskhan',
+                                    'lucario',
+                                    'bisharp',
+                                    'lucariomega')]
+
+        teams = [movesets[:6],
+                 movesets[6:12],
+                 [movesets[i] for i in (1, 12, 3, 4, 5, 6)],
+                 [movesets[i] for i in (3, 5, 6, 8, 9, 13)]]
+
+        logs = [lg.generate_log(players[:2], teams[:2]),
+                lg.generate_log(players[2:4], teams[2:]),
+                lg.generate_log((players[1], players[4]), (teams[1], teams[0]))]
+
+        os.makedirs('xgs/tj')
+        for i, log in enumerate(logs):
+            json.dump(log, open('xgs/tj/battle-{1}-{0}.log.json'
+                                .format(i + 1, log['p1rating']['formatid']),
+                                'w+'))
+
+        self.p = lp.LogProcessor(StumpMovesetSink(), StumpBattleInfoSink(),
+                                 None)
+
+    def check(self, result):
+        assert 3 == result
+
+        assert 11 == len(self.p.moveset_sink.sids)
+        assert 4 == len(self.p.battle_info_sink.pids)
+        assert 4 == len(self.p.battle_info_sink.tids)
+        assert {'uu', 'ou'} == set(self.p.battle_info_sink.battles.keys())
+        assert 2 == len(self.p.battle_info_sink.battles['uu'])
+        assert 1 == len(self.p.battle_info_sink.battles['ou'])
+
+    def test_one_log_at_a_time(self):
+
+        result = 0
+        result += self.p.process_logs('xgs/tj/battle-uu-1.log.json',
+                                      ref_type='file')
+        result += self.p.process_logs('xgs/tj/battle-ou-2.log.json',
+                                      ref_type='file')
+        result += self.p.process_logs('xgs/tj/battle-uu-3.log.json',
+                                      ref_type='file')
+        self.check(result)
+
+    def test_with_list_of_files(self):
+        result = self.p.process_logs(('xgs/tj/battle-uu-1.log.json',
+                                      'xgs/tj/battle-ou-2.log.json',
+                                      'xgs/tj/battle-uu-3.log.json'),
+                                     ref_type='files')
+        self.check(result)
+
+    def test_with_folder(self):
+        result = self.p.process_logs('xgs/tj', ref_type='folder')
+        self.check(result)
+
+    def test_with_nested_folder(self):
+        result = self.p.process_logs('xgs', ref_type='folder')
+        self.check(result)
+
+    def test_with_multiple_ref_types(self):
+        result = 0
+        result += self.p.process_logs('xgs/tj/battle-ou-2.log.json',
+                                      ref_type='file')
+        result += self.p.process_logs(('xgs/tj/battle-uu-1.log.json',
+                                       'xgs/tj/battle-uu-3.log.json'),
+                                      ref_type='files')
+        self.check(result)
+
+    def teardown_method(self, method):
+        shutil.rmtree('xgs', ignore_errors=True)
 
 
 

--- a/onix/tests/collection/test_log_processor.py
+++ b/onix/tests/collection/test_log_processor.py
@@ -74,11 +74,6 @@ def test_processor_without_sinks():
                                 date=datetime.datetime(2016, 8, 31))
         assert 1 == result
 
-        assert 1 == len(p.readers)
-        reader = list(p.readers.values())[0]
-        assert isinstance(reader, lr.JsonFileLogReader)
-        assert 'randombattle' == reader.metagame
-
     finally:
         os.remove('egagadga.log.json')
 
@@ -117,15 +112,11 @@ def test_process_single_log():
                                 date=datetime.datetime(2016, 8, 31))
         assert 1 == result
 
-        assert 1 == len(p.readers)
-        reader = list(p.readers.values())[0]
-        assert isinstance(reader, lr.JsonFileLogReader)
-        assert 'ou' == reader.metagame
-
         assert 11 == len(p.moveset_sink.sids)
         assert 2 == len(p.battle_info_sink.pids)
         assert 2 == len(p.battle_info_sink.tids)
-        assert 1 == len(p.battle_info_sink.battles)
+        assert {'ou'} == set(p.battle_info_sink.battles.keys())
+        assert 1 == len(p.battle_info_sink.battles['ou'])
 
     finally:
         os.remove('wtafda.log.json')

--- a/onix/tests/collection/test_log_processor.py
+++ b/onix/tests/collection/test_log_processor.py
@@ -69,9 +69,7 @@ def test_processor_without_sinks():
         json.dump(log, open('battle-randombattle-134341313.log.json', 'w+'))
         p = lp.LogProcessor(None, None, None)
         result = p.process_logs('battle-randombattle-134341313.log.json',
-                                ref_type='file',
-                                format='randombattle',
-                                date=datetime.datetime(2016, 8, 31))
+                                ref_type='file')
         assert 1 == result
 
     finally:
@@ -167,8 +165,8 @@ class TestProcessMultipleLogs(object):
     def check(self, result):
         assert 3 == result
 
-        assert 11 == len(self.p.moveset_sink.sids)
-        assert 4 == len(self.p.battle_info_sink.pids)
+        assert 14 == len(self.p.moveset_sink.sids)
+        assert 5 == len(self.p.battle_info_sink.pids)
         assert 4 == len(self.p.battle_info_sink.tids)
         assert {'uu', 'ou'} == set(self.p.battle_info_sink.battles.keys())
         assert 2 == len(self.p.battle_info_sink.battles['uu'])


### PR DESCRIPTION
Resolves #17 

Currently
- Only supports "standard" metagames
- Only supports processing `.log.json` files (there's nothing else right now)
- Only supports two error-handling modes: skip and raise.
